### PR TITLE
Decorator shouldn't fail.

### DIFF
--- a/test_gen.py
+++ b/test_gen.py
@@ -1,4 +1,3 @@
-import cStringIO
 import os.path
 from hashlib import md5
 
@@ -11,7 +10,7 @@ class HashableDict(dict):
 class UnitTestFactory(object):
     TESTCASE_FILENAME = 'unittests.py'
 
-    def setupfile(self,filepaths):
+    def setupfile(self, filepaths):
         """
             Create a file with header imports etc
         """
@@ -25,7 +24,6 @@ class UnitTestFactory(object):
                     f.write('class SimpleTest(unittest.TestCase):\n\n')
                 except AttributeError:
                     print 'attribute err'
-
 
     def create_test_case_line(self, data, prefix=TESTCASE_PREFIX):
         """
@@ -99,7 +97,7 @@ class test_logger(object):
         if not kwargs:
             kwargs = {}
         kwargs = HashableDict(kwargs)
-        self.data[function_name,args,kwargs] = r
+        self.data[function_name, args, kwargs] = r
         return r
 
     def __del__(self):
@@ -107,11 +105,11 @@ class test_logger(object):
             self.unittestfile.setupfile(filepaths=self.filepath)
             data = self.unittestfile.read_test_file()
             for fn, args, kwargs in self.data:
-                funct_result = self.data[fn,args,kwargs]
-                r = {'fn':fn,
-                     'args':args,
-                     'kwargs':kwargs,
-                     'result':funct_result
+                funct_result = self.data[fn, args, kwargs]
+                r = {'fn': fn,
+                     'args': args,
+                     'kwargs': kwargs,
+                     'result': funct_result
                      }
                 funct_arg_sig = str(r)
                 if eval(funct_arg_sig) not in data:

--- a/test_gen.py
+++ b/test_gen.py
@@ -96,8 +96,11 @@ class test_logger(object):
             args = ()
         if not kwargs:
             kwargs = {}
-        kwargs = HashableDict(kwargs)
-        self.data[function_name, args, kwargs] = r
+        try:
+            kwargs = HashableDict(kwargs)
+            self.data[function_name, args, kwargs] = r
+        except:
+            pass
         return r
 
     def __del__(self):

--- a/unittests.py
+++ b/unittests.py
@@ -1,12 +1,12 @@
 from test_1 import *
-from test_1 import *
-from test_1 import *
 import unittest
+
+
 class SimpleTest(unittest.TestCase):
 
 # testcase:{'args': (), 'result': 44, 'fn': 'simplefn', 'kwargs': {'a': 2, 'b': 3}}
     def test_simplefn_1c419a(self):
-        self.assertEqual(simplefn(*(), **{'a': 2, 'b': 3}), 44)
+        self.assertEqual(simplefn(*(), **{'a': 2, 'b': 3}), 44444)
 
 # testcase:{'args': (), 'result': 44, 'fn': 'simplefn', 'kwargs': {'a': 2, 'b': 4}}
     def test_simplefn_f8867a(self):


### PR DESCRIPTION
If the decorator fails, for whatever reason, the function should still be returned.

Question: I don't like that I'm adding a catch-all `except` at https://github.com/julzhk/autogenerate_functional_tests/compare/master...niceguydave:master#diff-417ed73841bcdb1e7836167433822c3aL101 but I'm unsure what kind of exceptions we need to deal with here. Do you think it's acceptable to just catch everything?
